### PR TITLE
Fix reference from iteritems() to items() in Pyramid and bump version.

### DIFF
--- a/pyramid_cachebust/cachebust.py
+++ b/pyramid_cachebust/cachebust.py
@@ -79,7 +79,7 @@ class CacheBust(object):
 
         settings = {
             k.replace('cachebust.', ''): v
-            for k, v in settings.iteritems()
+            for k, v in settings.items()
             if k.startswith('cachebust.')
         }
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
 ]
 
 setup(name='pyramid_cachebust',
-      version='0.1',
+      version='0.1.1',
       description='Nascent cache busting for the Pyramid web framework',
       classifiers=[
         "Framework :: Pyramid",


### PR DESCRIPTION
I believe in Python 3, they removed .iteritems() from dict.  This should work in Py2 and Py3 now.
